### PR TITLE
Add option for using buffered observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ g.o.observe({entryTypes:['longtask']})}}();
 
 *__Note:__ this snippet is a temporary workaround, until browsers implement level 2 of the Performance Observer spec and include the [`buffered`](https://w3c.github.io/performance-timeline/#dom-performanceobserverinit-buffered) flag.*
 
+*__Note 2:__ Step 1 mentioned above can be skipped when using `useBufferedObserver` option at initialization. Only works in recent versions of modern browsers(i.e. [Chrome 81+](https://www.chromestatus.com/feature/6306761277440000)).
+
 The second step is to import the module into your application code and invoke the `getFirstConsistentlyInteractive()` method. The `getFirstConsistentlyInteractive()` method returns a promise that resolves to the TTI metric value (in milliseconds since navigation start). If no TTI value can be found, or if the browser doesn't support all the APIs required to detect TTI, the promise resolves to `null`.
 
 ```js
@@ -59,6 +61,13 @@ The following table outlines the configuration options you can pass to the `getF
     <td><code>boolean</code></td>
     <td>
       When true (the default), a mutation observer is used to detect when added DOM elements will create additional network requests. This can be disabled to improve performance in cases where you know no additional request-creating DOM elements will be added.
+    </td>
+  </tr>
+  <tr valign="top">
+    <td><code>useBufferedObserver</code></td>
+    <td><code>boolean</code></td>
+    <td>
+      When true, buffered performance entries, buffered via `PerformanceObserver`, emitted before the initialization of tti-polyfill will be taken into account. Defautls to `false`.
     </td>
   </tr>
 </table>

--- a/src/externs.js
+++ b/src/externs.js
@@ -37,6 +37,7 @@ window.__tti.e;
 /**
  * @typedef {{
  *   useMutationObserver: (boolean|undefined),
+ *   useBufferedObserver: (boolean|undefined),
  * }}
  */
 var FirstConsistentlyInteractiveDetectorInit;
@@ -51,7 +52,9 @@ function PerformanceObserverEntry() {}
 /**
  * Options for the PerformanceObserver.
  * @typedef {{
- *   entryTypes: (Array<string>),
+ *   entryTypes: (Array<string>|undefined),
+ *   type: (string|undefined),
+ *   buffered: (boolean|undefined),
  * }}
  */
 var PerformanceObserverInit;


### PR DESCRIPTION
Fixes https://github.com/GoogleChromeLabs/tti-polyfill/issues/17

Adds option to use buffered `PerformanceObserver` observations. This will allow using the tti-polyfill library without having to add the "snippet" mentioned in https://github.com/GoogleChromeLabs/tti-polyfill#usage . The option defaults to false meaning if the `useBufferedObserver` option was not set at the initialization of the library, it will default to using non-buffered observations as it did in the prior versions of the library. Usage of buffered observers can be enabled by initializing the library as follows `ttiPolyfill.getFirstConsistentlyInteractive({ useBufferedObserver: true })`.

@philipwalton I was unable to run the tests, they don't run on modern browsers. First I ran into cors issue, I disabled it in a chromium instance but then I started running into module loading issues with strict mime type checking enforcements. 

I got a local built but did not commit the build. I am assuming you get a build and push the builds when making releases? There wasn't a lot of explanation on contribution guidelines.